### PR TITLE
Framework for Converters

### DIFF
--- a/source/transpiler/__init__.py
+++ b/source/transpiler/__init__.py
@@ -1,0 +1,1 @@
+from .toolpathConverter import ToolpathConverter

--- a/source/transpiler/__init__.py
+++ b/source/transpiler/__init__.py
@@ -1,1 +1,3 @@
 from .toolpathConverter import ToolpathConverter
+from .nscryptConverter import NscryptConverter
+from .acsplConverter import AcsplConverter

--- a/source/transpiler/__main__.py
+++ b/source/transpiler/__main__.py
@@ -28,9 +28,10 @@ def configureAndStartLogger():
     logger.addHandler(logHandler)
 
     # Print Header for Log File
+    formatted_time = now.strftime("%c")
     logger.info("===============TRANSPILER=====================")
     logger.info(f"File Name: transpiler-{time}.log")
-    logger.info(f"Start Time: {now.strftime("%c")}")
+    logger.info(f"Start Time: {formatted_time}")
     logger.info("==============================================")
 
 # Main Entry Point

--- a/source/transpiler/acsplConverter.py
+++ b/source/transpiler/acsplConverter.py
@@ -1,2 +1,4 @@
 from . import ToolpathConverter
 
+class AcsplConverter(ToolpathConverter):
+    pass

--- a/source/transpiler/acsplConverter.py
+++ b/source/transpiler/acsplConverter.py
@@ -1,0 +1,2 @@
+from . import ToolpathConverter
+

--- a/source/transpiler/acsplConverter.py
+++ b/source/transpiler/acsplConverter.py
@@ -1,4 +1,28 @@
 from . import ToolpathConverter
+from typing import List
+
+COMMAND_MAP: dict[str,str] = {
+    "GenericCommand" : "ACSPL Command"
+}
 
 class AcsplConverter(ToolpathConverter):
-    pass
+    def __init__(self):
+        super().__init__(COMMAND_MAP)
+
+    def _get_command(self, command: dict[str, dict[str, str]]) -> str:
+        """
+        Performs translation of a single command
+        :param command: individual command to be translated
+        :return: string representation of the translated command
+        """
+        # TODO: perform translation of single command
+        pass
+
+    def translate(self, parsed_commands: List[dict[str, dict[str, str]]]) -> List[str]:
+        """
+        Translates generic toolpath to list of formatted commands
+        :param parsed_commands: list of commands to be translated from generic parser
+        :return: list of strings that are translated commands
+        """
+        # TODO: perform translation of list of commands
+        pass

--- a/source/transpiler/nscryptConverter.py
+++ b/source/transpiler/nscryptConverter.py
@@ -1,0 +1,1 @@
+from . import ToolpathConverter

--- a/source/transpiler/nscryptConverter.py
+++ b/source/transpiler/nscryptConverter.py
@@ -1,4 +1,28 @@
 from . import ToolpathConverter
+from typing import List
+
+COMMAND_MAP: dict[str,str] = {
+    "GenericCommand" : "nScrypt Command"
+}
 
 class NscryptConverter(ToolpathConverter):
-    pass
+    def __init__(self):
+        super().__init__(COMMAND_MAP)
+
+    def _get_command(self, command: dict[str, dict[str, str]]) -> str:
+        """
+        Performs translation of a single command
+        :param command: individual command to be translated
+        :return: string representation of the translated command
+        """
+        # TODO: perform translation of single command
+        pass
+
+    def translate(self, parsed_commands: List[dict[str, dict[str, str]]]) -> List[str]:
+        """
+        Translates generic toolpath to list of formatted commands
+        :param parsed_commands: list of commands to be translated from generic parser
+        :return: list of strings that are translated commands
+        """
+        # TODO: perform translation of list of commands
+        pass

--- a/source/transpiler/nscryptConverter.py
+++ b/source/transpiler/nscryptConverter.py
@@ -1,1 +1,4 @@
 from . import ToolpathConverter
+
+class NscryptConverter(ToolpathConverter):
+    pass

--- a/source/transpiler/toolpathConverter.py
+++ b/source/transpiler/toolpathConverter.py
@@ -7,13 +7,19 @@ class ToolpathConverter:
     def __init__(self):
         # Stores the mapping from the generic command to desired machine's command
         self.commandMap: dict[str, str] = {}
-        # Stores list of translated commands
-        self.convertedCommands: List[str] = []
 
-    # Performs translation of a single command
-    def _getCommand(self):
+    def _get_command(self, command: dict[str, dict[str,str]]) -> str:
+        """
+        Performs translation of a single command
+        :param command: individual command to be translated
+        :return:
+        """
         pass
 
-    # Translates generic toolpath to list of formatted commands
-    def translate(self):
+    def translate(self, parsed_commands: List[dict[str, dict[str, str]]]) -> List[str]:
+        """
+        Translates generic toolpath to list of formatted commands
+        :param parsed_commands: list of commands to be translated from generic parser
+        :return:
+        """
         pass

--- a/source/transpiler/toolpathConverter.py
+++ b/source/transpiler/toolpathConverter.py
@@ -12,7 +12,7 @@ class ToolpathConverter:
         """
         Performs translation of a single command
         :param command: individual command to be translated
-        :return:
+        :return: string representation of the translated command
         """
         pass
 
@@ -20,6 +20,6 @@ class ToolpathConverter:
         """
         Translates generic toolpath to list of formatted commands
         :param parsed_commands: list of commands to be translated from generic parser
-        :return:
+        :return: list of strings that are translated commands
         """
         pass

--- a/source/transpiler/toolpathConverter.py
+++ b/source/transpiler/toolpathConverter.py
@@ -1,0 +1,19 @@
+from typing import List
+
+# Parent Class for Generic to Language Specific Conversion
+class ToolpathConverter:
+
+    # Initializer
+    def __init__(self):
+        # Stores the mapping from the generic command to desired machine's command
+        self.commandMap: dict[str, str] = {}
+        # Stores list of translated commands
+        self.convertedCommands: List[str] = []
+
+    # Performs translation of a single command
+    def _getCommand(self):
+        pass
+
+    # Translates generic toolpath to list of formatted commands
+    def translate(self):
+        pass

--- a/source/transpiler/toolpathConverter.py
+++ b/source/transpiler/toolpathConverter.py
@@ -3,14 +3,18 @@ from typing import List
 # Parent Class for Generic to Language Specific Conversion
 class ToolpathConverter:
 
-    # Initializer
-    def __init__(self):
+    def __init__(self, command_map: dict[str,str]):
+        """
+        :param command_map: Dictionary of generic command to language specific command
+        """
+
         # Stores the mapping from the generic command to desired machine's command
-        self.commandMap: dict[str, str] = {}
+        self._command_map: dict[str, str] = command_map
 
     def _get_command(self, command: dict[str, dict[str,str]]) -> str:
         """
         Performs translation of a single command
+        To be overwritten in inherited classes
         :param command: individual command to be translated
         :return: string representation of the translated command
         """
@@ -19,6 +23,7 @@ class ToolpathConverter:
     def translate(self, parsed_commands: List[dict[str, dict[str, str]]]) -> List[str]:
         """
         Translates generic toolpath to list of formatted commands
+        To be overwritten in inherited classes
         :param parsed_commands: list of commands to be translated from generic parser
         :return: list of strings that are translated commands
         """

--- a/tests/ReadME.md
+++ b/tests/ReadME.md
@@ -1,2 +1,4 @@
 This folder will house our tests.
 
+# Naming Convention
+- Test files should be named `test_<module_name>.py`

--- a/tests/test_acsplConverter.py
+++ b/tests/test_acsplConverter.py
@@ -1,0 +1,1 @@
+import pytest

--- a/tests/test_nscryptConverter.py
+++ b/tests/test_nscryptConverter.py
@@ -1,0 +1,1 @@
+import pytest


### PR DESCRIPTION
This pull request introduces several new features and improvements to the `source/transpiler` module, including the addition of new converter classes and updates to the logging configuration. Additionally, it includes updates to the test suite.

New converter classes and base class:

* [`source/transpiler/toolpathConverter.py`](diffhunk://#diff-c5a8ad2966b6e1f3c33fbb764ce60463bccd1f2f0deb6d3f153fd32595245990R1-R30): Introduced `ToolpathConverter` base class to handle generic to language-specific command translation.
* [`source/transpiler/acsplConverter.py`](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eR1-R28): Added `AcsplConverter` class inheriting from `ToolpathConverter` for ACSPL command translation.
* [`source/transpiler/nscryptConverter.py`](diffhunk://#diff-19de37a8c4bb4b74d200cce0e6c49d79b46e2da7057d0428e64e230a91290a6aR1-R28): Added `NscryptConverter` class inheriting from `ToolpathConverter` for nScrypt command translation.

Logging configuration update:

* [`source/transpiler/__main__.py`](diffhunk://#diff-dda38f8b0847603cacf7370178b85baca357fdf1fb4216b3c10ccdde4c1d9fdcR31-R34): Updated `configureAndStartLogger` function to store the formatted start time in a variable before logging it due to fstrings producing errors in python 3.11 

Test suite updates:

* [`tests/ReadME.md`](diffhunk://#diff-8c6ab6731bb60429183ad85b4dd171ea104eed48163c54184b7c75d79f73c421R3-R4): Added naming convention for test files.
* `tests/test_acsplConverter.py` and `tests/test_nscryptConverter.py`: Added `pytest` import to the test files.