### PR TITLE
Expanded Parser to ACSPL Converter Integration Tests

### DIFF
--- a/tests/test_int_genParser_acsplConverter.py
+++ b/tests/test_int_genParser_acsplConverter.py
@@ -73,7 +73,18 @@ class TestIntegrationParserToACSPL(unittest.TestCase):
 
     @patch("builtins.open", new_callable=mock_open, read_data="INVALIDCOMMAND / 1.0, 2.0, 3.0")
     def test_invalid_command(self, mock_file):
-        pass
+        # Arrange, use the mock to simulate an invalid command
+        mock_parser = GenericParser("invalid_command.ncl.1")
+
+        # Act
+        parsed_commands = mock_parser.parse_commands()
+        translated_command = self.acsplConverter.translate(parsed_commands)
+
+        # Assert
+        self.assertEqual(len(parsed_commands), 0) # Ensure the command was not processed by parser
+        self.assertEqual(len(translated_command), 0) # Ensure the command was not translated by converter
+        self.assertIn("INVALIDCOMMAND", mock_parser.unparsedCommands[0]) # Ensure the invalid command is in the unparsed list
+
 
     # TODO remove this test before delivery
     def test_print(self):

--- a/tests/test_int_genParser_acsplConverter.py
+++ b/tests/test_int_genParser_acsplConverter.py
@@ -95,6 +95,26 @@ class TestIntegrationParserToACSPL(unittest.TestCase):
         self.assertEqual(len(translated_command), 0) # Ensure the command was not translated by converter
         self.assertIn("INVALIDCOMMAND", mock_parser.unparsedCommands[0]) # Ensure the invalid command is in the unparsed list
 
+    @patch("builtins.open", new_callable=mock_open, read_data="COOLNT / ON")
+    def test_ignored_command(self, mock_file):
+        """
+        Ensures a command that is supported by parser, but not converter is processed correctly.
+        Parser should process the command but the converter should not.
+        """
+        # Arrange, use the mock to simulate an ignored command
+        mock_parser = GenericParser("ignored_command.ncl.1")
+
+        # Act
+        parsed_commands = mock_parser.parse_commands()
+        translated_command = self.acsplConverter.translate(parsed_commands)
+
+        # Assert
+        # Ensure the command was processed by the parser
+        self.assertEqual(len(parsed_commands), 1)
+        # Ensure the command was not translated by the converter, there should only be 3 lines appended
+        # the machine setup code block, a start comment, and the stop code block
+        self.assertEqual(len(translated_command), 3)
+
     # TODO remove this test before delivery
     def test_print(self):
         # Arrange
@@ -102,8 +122,8 @@ class TestIntegrationParserToACSPL(unittest.TestCase):
         # Act
         translated_commands = self.acsplConverter.translate(parsed_commands)
         # Assert
-        for command in translated_commands:
-            print(command)
+        #for command in translated_commands:
+            #print(command)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_int_genParser_acsplConverter.py
+++ b/tests/test_int_genParser_acsplConverter.py
@@ -10,12 +10,16 @@ from parser import GenericParser
 
 class TestIntegrationParserToACSPL(unittest.TestCase):
     def setUp(self):
-        """ Set up the test environment. """
+        """
+        Set up the test environment.
+        """
         self.acsplConverter = AcsplConverter()
         self.genericParser = GenericParser("../tests/resources/op010.ncl.1")
 
     def test_conversion_to_translate_noException(self):
-        """ Ensure parsing and conversion do not raise any exceptions. """
+        """
+        Ensure parsing and conversion do not raise any exceptions.
+        """
         # Arrange
         parsed_commands = self.genericParser.parse_commands() # Parse the file and get the parsed commands
 
@@ -60,6 +64,9 @@ class TestIntegrationParserToACSPL(unittest.TestCase):
 
     @patch("builtins.open", new_callable=mock_open, read_data="")
     def test_empty_input_file(self, mock_file):
+        """
+        Ensure an empty file does not raise any exceptions and does not get processed.
+        """
         # Arrange, use the mock to simulate an empty file
         mock_parser = GenericParser("empty_file.ncl.1")
 
@@ -73,6 +80,9 @@ class TestIntegrationParserToACSPL(unittest.TestCase):
 
     @patch("builtins.open", new_callable=mock_open, read_data="INVALIDCOMMAND / 1.0, 2.0, 3.0")
     def test_invalid_command(self, mock_file):
+        """
+        Ensure an invalid command does not raise any exceptions and does not get processed.
+        """
         # Arrange, use the mock to simulate an invalid command
         mock_parser = GenericParser("invalid_command.ncl.1")
 
@@ -84,7 +94,6 @@ class TestIntegrationParserToACSPL(unittest.TestCase):
         self.assertEqual(len(parsed_commands), 0) # Ensure the command was not processed by parser
         self.assertEqual(len(translated_command), 0) # Ensure the command was not translated by converter
         self.assertIn("INVALIDCOMMAND", mock_parser.unparsedCommands[0]) # Ensure the invalid command is in the unparsed list
-
 
     # TODO remove this test before delivery
     def test_print(self):

--- a/tests/test_int_genParser_acsplConverter.py
+++ b/tests/test_int_genParser_acsplConverter.py
@@ -1,5 +1,9 @@
+# Utility Imports
 import unittest
+from unittest.mock import patch, mock_open # For mocking the file
 import sys
+
+# Transpiler Imports
 sys.path.append("../source/transpiler/")
 from acsplConverter import AcsplConverter
 from parser import GenericParser
@@ -52,6 +56,21 @@ class TestIntegrationParserToACSPL(unittest.TestCase):
         # Ensure all commands are strings
         for command in translated_commands:
             self.assertIsInstance(command, str)
+
+
+    @patch("builtins.open", new_callable=mock_open, read_data="")
+    def test_empty_input_file(self, mock_file):
+        # Arrange, use the mock to simulate an empty file
+        mock_parser = GenericParser("empty_file")
+
+        # Act
+        parsed_commands = mock_parser.parse_commands()
+        translated_command = self.acsplConverter.translate(parsed_commands)
+
+        # Assert
+        self.assertEqual(len(parsed_commands), 0) # Ensure no commands were parsed
+        self.assertEqual(len(translated_command), 0) # Ensure no commands were translated
+
 
     # TODO remove this test before delivery
     def test_print(self):

--- a/tests/test_int_genParser_acsplConverter.py
+++ b/tests/test_int_genParser_acsplConverter.py
@@ -6,10 +6,12 @@ from parser import GenericParser
 
 class TestIntegrationParserToACSPL(unittest.TestCase):
     def setUp(self):
+        """ Set up the test environment. """
         self.acsplConverter = AcsplConverter()
         self.genericParser = GenericParser("../tests/resources/op010.ncl.1")
 
     def test_conversion_to_translate_noException(self):
+        """ Ensure parsing and conversion do not raise any exceptions. """
         # Arrange
         parsed_commands = self.genericParser.parse_commands() # Parse the file and get the parsed commands
 
@@ -20,6 +22,10 @@ class TestIntegrationParserToACSPL(unittest.TestCase):
             self.fail(f"Exception raised during translation: {e}")
 
     def test_conversion_to_translation_noInvalidCommands(self):
+        """
+        Ensure translated output does not contain invalid commands, as all in the current
+        Creo file are supported.
+        """
         # Arrange
         parsed_commands = self.genericParser.parse_commands()
 
@@ -29,6 +35,23 @@ class TestIntegrationParserToACSPL(unittest.TestCase):
         # Assert
         for command in translated_commands:
             self.assertNotIn("INVALID", command)
+
+    def test_conversion_to_translation_typeCheck(self):
+        """
+        Ensure the translated output is a list of strings.
+        """
+        # Arrange
+        parsed_commands = self.genericParser.parse_commands()
+
+        # Act
+        translated_commands = self.acsplConverter.translate(parsed_commands)
+
+        # Assert
+        self.assertIsInstance(translated_commands, list) # Ensure the output is a list
+        self.assertGreater(len(translated_commands), 0) # Ensure there are commands
+        # Ensure all commands are strings
+        for command in translated_commands:
+            self.assertIsInstance(command, str)
 
     # TODO remove this test before delivery
     def test_print(self):

--- a/tests/test_int_genParser_acsplConverter.py
+++ b/tests/test_int_genParser_acsplConverter.py
@@ -61,7 +61,7 @@ class TestIntegrationParserToACSPL(unittest.TestCase):
     @patch("builtins.open", new_callable=mock_open, read_data="")
     def test_empty_input_file(self, mock_file):
         # Arrange, use the mock to simulate an empty file
-        mock_parser = GenericParser("empty_file")
+        mock_parser = GenericParser("empty_file.ncl.1")
 
         # Act
         parsed_commands = mock_parser.parse_commands()
@@ -71,6 +71,9 @@ class TestIntegrationParserToACSPL(unittest.TestCase):
         self.assertEqual(len(parsed_commands), 0) # Ensure no commands were parsed
         self.assertEqual(len(translated_command), 0) # Ensure no commands were translated
 
+    @patch("builtins.open", new_callable=mock_open, read_data="INVALIDCOMMAND / 1.0, 2.0, 3.0")
+    def test_invalid_command(self, mock_file):
+        pass
 
     # TODO remove this test before delivery
     def test_print(self):


### PR DESCRIPTION
This pull request includes several enhancements and new test cases to the `tests/test_int_genParser_acsplConverter.py` file. The changes aim to improve the robustness and coverage of the unit tests for the `AcsplConverter` and `GenericParser` classes.

Enhancements to test cases:

* Added docstrings to existing test methods to provide descriptions of their purposes. [[1]](diffhunk://#diff-3d7362721c876a6d399838a54ed72f26f5ca5a5ec3e50dae0d10a5c02d91b4e9R1-R22) [[2]](diffhunk://#diff-3d7362721c876a6d399838a54ed72f26f5ca5a5ec3e50dae0d10a5c02d91b4e9R33-R36)

New test cases:

* Added `test_conversion_to_translation_typeCheck` to ensure the translated output is a list of strings.
* Added `test_empty_input_file` to ensure an empty file does not raise any exceptions and does not get processed.
* Added `test_invalid_command` to ensure an invalid command does not raise any exceptions and does not get processed.
* Added `test_ignored_command` to ensure a command supported by the parser but not the converter is processed correctly.