### PR TITLE
Check extension of filepath before accepting

### DIFF
--- a/source/transpiler/guiRoot.py
+++ b/source/transpiler/guiRoot.py
@@ -146,7 +146,12 @@ class GuiRoot(tk.Tk):
 
         # A file is selected successfully in the file dialog
         else:
-            
+
+            # Check if file selected is of proper extension
+            if not filepath.endswith('.ncl.1'):
+                self.writeStatus("Select Import File Error: Invalid file type. Please select a .ncl.1 file.")
+                return
+
             # The file dialog already handles when the user tries to input an invalid file name
             # for redundancy, check if the file can be opened
 


### PR DESCRIPTION
Addressing the issue of the user not being informed if the file selected is invalid. 

*UnicodeDecodeError and TypeError occurs but user does not get notified.*
![image](https://github.com/user-attachments/assets/8c0fb6aa-0675-4aed-8638-a131d9cba768)

with changes, user is now notified and no error occurs.

![image](https://github.com/user-attachments/assets/1e9f7137-d283-4a7f-9537-16b1c90366c5)

