### PR TITLE
ACSPL 5 Axis Extension

### DIFF
--- a/source/transpiler/acsplConverter.py
+++ b/source/transpiler/acsplConverter.py
@@ -333,13 +333,16 @@ class AcsplConverter(ToolpathConverter):
 
         # If the command is a move command
         elif command == "move":
-            # TODO: Extend to support 5 axis
 
             # Classify the type of move command
             # If not dispensing, the ACSPL movement is "PTP"
             if not self.machine.is_dispensing:
                 # Set the location registers for the machine to store desired location
-                self.machine.set_axis_registers(params["x"], params["y"], params["z"])
+                self.machine.set_axis_registers(params["x"],
+                                                params["y"],
+                                                params["z"],
+                                                params.get("a", 0.0),
+                                                params.get("b", 0.0))
                 # Format and append the PTP command
                 self._format_and_append_command("PTP", "EV")
                 return
@@ -351,7 +354,11 @@ class AcsplConverter(ToolpathConverter):
                 # Set the machine to be in printing segment
                 self.machine.in_printing_segment = True
                 # Set the location registers for the machine to store desired location
-                self.machine.set_axis_registers(params["x"], params["y"], params["z"])
+                self.machine.set_axis_registers(params["x"],
+                                                params["y"],
+                                                params["z"],
+                                                params.get("a", 0.0),
+                                                params.get("b", 0.0))
                 # Format and append the LINE command
                 self._format_and_append_command("LINE", "V")
                 return
@@ -359,7 +366,11 @@ class AcsplConverter(ToolpathConverter):
             # If dispensing, the ACSPL movement is "LINE"
             elif self.machine.in_printing_segment:
                 # Set the location registers for the machine to store desired location
-                self.machine.set_axis_registers(params["x"], params["y"], params["z"])
+                self.machine.set_axis_registers(params["x"],
+                                                params["y"],
+                                                params["z"],
+                                                params.get("a", 0.0),
+                                                params.get("b", 0.0))
                 # Format and append the LINE command
                 self._format_and_append_command("LINE", "V")
                 return
@@ -388,7 +399,11 @@ class AcsplConverter(ToolpathConverter):
         # If the command is an arc command
         elif command == "arc":
             # Set the location registers for the machine to store desired location
-            self.machine.set_axis_registers(params["x"], params["y"], params["z"])
+            self.machine.set_axis_registers(params["x"],
+                                            params["y"],
+                                            params["z"],
+                                            params.get("a", 0.0),
+                                            params.get("b", 0.0))
             # Format and append the ARC command
             self._format_and_append_command("ARC")
 

--- a/source/transpiler/acsplConverter.py
+++ b/source/transpiler/acsplConverter.py
@@ -167,7 +167,7 @@ class Machine:
         """
         self._done = done
 
-    def set_axis_registers(self, x: any, y: any, z: any, a: any = 0.0, b: any = 0.0) -> None:
+    def set_axis_registers(self, x: any, y: any, z: any, a: any, b: any) -> None:
         """
         Set the axis registers for the machine
         :param x: desired location for x-axis


### PR DESCRIPTION
This pull request introduces changes to the `source/transpiler/acsplConverter.py` file to extend support for 5-axis movement commands. The most important changes involve modifying the `_process_command` method to handle additional axes "a" and "b" in various movement commands.

Support for 5-axis movement:

* [`source/transpiler/acsplConverter.py`](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eL336-R345): Updated the `move` command to set axis registers for "a" and "b" axes using default values if not provided.
* [`source/transpiler/acsplConverter.py`](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eL354-R373): Updated the printing segment handling to set axis registers for "a" and "b" axes using default values if not provided.
* [`source/transpiler/acsplConverter.py`](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eL391-R406): Updated the `arc` command to set axis registers for "a" and "b" axes using default values if not provided.