### PR TITLE
GUI Changes #2

### DIFF
--- a/source/transpiler/guiRoot.py
+++ b/source/transpiler/guiRoot.py
@@ -278,8 +278,6 @@ class GuiRoot(tk.Tk):
     Function that is called when the "Printer Parameter" button is clicked
     '''
     def printParamsButtonCallback(self):
-        self.writeStatus("Printer Parameters Click")
-        print("Printer Parameters Click")
         paramWindow = tk.Toplevel()
         self.eval("tk::PlaceWindow {} center".format(str(paramWindow)))
         paramWindow.grab_set()
@@ -391,17 +389,25 @@ class ConversionSettingsFrame(tk.Frame):
         self.printerTypeCombobox = ttk.Combobox(self.printerTypeSelectFrame, values=globals.PRINTER_TYPES, state="readonly")
         self.printerTypeCombobox.current(globals.printerTypeSelected)
         self.printerTypeCombobox.pack(side="left")
+        
+        self.printerTypeSelectFrame.pack(padx=10, pady=10)
 
-        self.printerTypeSelectFrame.pack(padx=50, pady=50)
+        self.menuButtonsFrame = tk.Frame(self)
+
+        self.saveButton = tk.Button(self.menuButtonsFrame, text="Save & Exit", command=self.saveButtonCallback)
+        self.cancelButton = tk.Button(self.menuButtonsFrame, text="Cancel", command=self.cancelButtonCallback)
+
+        self.saveButton.pack(padx=5, pady=5, side="left")
+        self.cancelButton.pack(padx=5, pady=5, side="left")
 
         #relates to if there are previously saved params or not
-        if parent.master.hasProfile == False:
-            self.savedSettingsStatusLabel = tk.Label(self.printerTypeSelectFrame, text="No previously saved settings, safe to choose")
-        else:
-            self.savedSettingsStatusLabel = tk.Label(self.printerTypeSelectFrame, text="There are pre-existing saved settings for the imported file, saving will override and clear current settings.")
-        self.savedSettingsStatusLabel.pack(side="left")
-        self.saveButton = tk.Button(self, text="Save", command=self.saveButtonCallback)
-        self.saveButton.pack(padx=10, pady=10)
+        self.savedSettingsStatusLabel = tk.Label(self, text="No previously saved settings, safe to choose")
+        if parent.master.hasProfile:
+            self.savedSettingsStatusLabel.configure(text="There are pre-existing saved settings for the imported file, saving will override and clear current settings.")
+            self.saveButton.configure(text="Overwrite Save & Exit")
+
+        self.savedSettingsStatusLabel.pack(padx=10, pady=10)
+        self.menuButtonsFrame.pack(padx=10, pady=10)
 
     def saveButtonCallback(self):
         globals.printerTypeSelected = self.printerTypeCombobox.current() #Set printer type global value
@@ -412,8 +418,14 @@ class ConversionSettingsFrame(tk.Frame):
         
         #TODO - Add more checks if needed
         self.saveSuccess = True
+        
+        # Close window after saving
+        self.master.destroy()
 
-        #TODO - Close window after saving? - Change to "Save and Exit"
+    def cancelButtonCallback(self):
+        # Close window without saving
+        globals.writeStatusQueue("Conversion Settings Not Saved (Cancelled)")
+        self.master.destroy()
 
 
 def queueLoop(rootObject):

--- a/source/transpiler/guiRoot.py
+++ b/source/transpiler/guiRoot.py
@@ -272,7 +272,8 @@ class GuiRoot(tk.Tk):
             elif globals.printerTypeSelected == 1:
                 self.params = OptomecParameters()
             
-            convSettingsFrame.saveSuccess = False # Reset
+            #TODO - if export_path != None, "change" extension of filepath
+            convSettingsFrame.saveSuccess = False # Reset save flag
 
     '''
     Function that is called when the "Printer Parameter" button is clicked
@@ -403,7 +404,7 @@ class ConversionSettingsFrame(tk.Frame):
         #relates to if there are previously saved params or not
         self.savedSettingsStatusLabel = tk.Label(self, text="No previously saved settings, safe to choose")
         if parent.master.hasProfile:
-            self.savedSettingsStatusLabel.configure(text="There are pre-existing saved settings for the imported file, saving will override and clear current settings.")
+            self.savedSettingsStatusLabel.configure(text="There are pre-existing saved settings for the imported file, saving will override and clear current settings/printer parameters.")
             self.saveButton.configure(text="Overwrite Save & Exit")
 
         self.savedSettingsStatusLabel.pack(padx=10, pady=10)

--- a/source/transpiler/guiRoot.py
+++ b/source/transpiler/guiRoot.py
@@ -206,6 +206,10 @@ class GuiRoot(tk.Tk):
                     self.params = OptomecParameters()
                 self.params.params = jdata[1]
                 self.hasProfile = True
+
+                self.printParams.configure(state="normal")
+                self.exportFileButton.configure(state="normal")
+
             except (KeyError, json.decoder.JSONDecodeError):
                 self.writeStatus("No existing parameter profile")
                 print("No existing parameter profile")
@@ -218,7 +222,6 @@ class GuiRoot(tk.Tk):
             self.hasProfile = False
 
         self.conversionSettings.configure(state="normal")
-        self.exportFileButton.configure(state="normal")
 
     '''
     Function that is called when the "Set Export Destination" button is clicked
@@ -271,10 +274,11 @@ class GuiRoot(tk.Tk):
         convSettingsWindow.wait_window()
         convSettingsWindow.grab_release() # Re-enables inputs into main menu while this window is open
 
-        self.printParams.configure(state="normal") #enable the params menu, eve if it was only clicked but not saved
         if(convSettingsFrame.saveSuccess): # Check if the save button was actually pressed
-            convSettingsFrame.saveSuccess = False # Reset save flag
+            self.printParams.configure(state="normal")
+            self.exportFileButton.configure(state="normal")
 
+            convSettingsFrame.saveSuccess = False # Reset save flag
             #save/set which parameter type after window is closed
             #only do this if they intentionally press the button rather than close out after seeing warning
             # "change" extension of filepath if it already exists
@@ -298,6 +302,7 @@ class GuiRoot(tk.Tk):
             if(extensionIndex > 0):
                 self.export_path = self.export_path[0:extensionIndex] + newExtension
                 self.setExportFilepathDisplay(self.export_path)
+            
 
     '''
     Function that is called when the "Printer Parameter" button is clicked
@@ -361,7 +366,6 @@ class GuiRoot(tk.Tk):
     '''
     def startConversionButtonCallback(self):
     
-        #TODO - Add checks if needed
         conversionAllowed = True
 
         if(self.import_path == None):
@@ -441,7 +445,6 @@ class ConversionSettingsFrame(tk.Frame):
         globals.writeStatusQueue("Conversion Settings Saved")
         globals.writeStatusQueue("Set Printer Type: " + selectedPrinter)
         
-        #TODO - Add more checks if needed
         self.saveSuccess = True
         
         # Close window after saving

--- a/source/transpiler/guiRoot.py
+++ b/source/transpiler/guiRoot.py
@@ -22,6 +22,7 @@ import json
 WINDOW_TITLE = "S25-38"  # TODO - Provide suitable titles
 MENU_TITLE = "S25-38 Machine Instruction Converter"
 GUI_WINDOW_SIZE = "800x400"
+TOOLPATH_PREVIEW_WINDOW_SIZE = "800x800"
 
 QUEUE_LOOP_RATE = 100
 
@@ -97,6 +98,11 @@ class GuiRoot(tk.Tk):
 
         self.exportFrame.pack(anchor="w", padx=5, pady=5, fill="x")
 
+        # Preview Toolpath Option
+        self.previewCheckValue = tk.IntVar()
+        self.previewCheck = tk.Checkbutton(self, text="Preview Toolpath", variable=self.previewCheckValue)
+        self.previewCheck.pack()
+
         # Start Conversion Button
         self.startConvButton = tk.Button(self, text="Start Conversion", command=self.startConversionButtonCallback)
         self.startConvButton.pack(anchor="center", padx=5, pady=5)
@@ -109,9 +115,9 @@ class GuiRoot(tk.Tk):
 
         # Status Text Area
         self.statusTextArea = tk.Text(self.statusFrame, wrap=tk.WORD)
-        self.statusTextArea.pack(anchor="w", fill="both", expand=True)
+        self.statusTextArea.pack(side="left", anchor="w", fill="both", expand=True)
 
-        self.statusTextAreaScrollbar = tk.Scrollbar(self.statusTextArea, command=self.statusTextArea.yview)
+        self.statusTextAreaScrollbar = tk.Scrollbar(self.statusFrame, command=self.statusTextArea.yview)
         self.statusTextAreaScrollbar.pack(side="right", fill="y")
 
         self.statusTextArea['yscrollcommand'] = self.statusTextAreaScrollbar.set
@@ -265,7 +271,6 @@ class GuiRoot(tk.Tk):
         self.eval("tk::PlaceWindow {} center".format(str(convSettingsWindow)))
 
         convSettingsWindow.title("Conversion Settings")
-    
         convSettingsWindow.resizable(False, False)
 
         convSettingsFrame = ConversionSettingsFrame(convSettingsWindow)
@@ -384,7 +389,27 @@ class GuiRoot(tk.Tk):
             
             # Obtained converted data
             converted_paths = conversionProcess(self.import_path, self.params, printer_type)
-            
+
+            # Check if preview option selected
+
+            if(self.previewCheckValue.get()):
+                toolpathPreviewWindow = tk.Toplevel()
+                toolpathPreviewWindow.grab_set()
+                self.eval("tk::PlaceWindow {} center".format(str(toolpathPreviewWindow)))
+                toolpathPreviewWindow.geometry(TOOLPATH_PREVIEW_WINDOW_SIZE)
+
+                toolpathPreviewWindow.title("Toolpath Preview")
+
+                previewFrame = ToolpathPreviewFrame(toolpathPreviewWindow, converted_paths)
+                previewFrame.pack(padx=5, pady=5, fill="both", expand=True)
+
+                toolpathPreviewWindow.wait_window()
+                toolpathPreviewWindow.grab_release()
+
+                if(previewFrame.cancelExport):
+                    self.writeStatus("Export Cancelled")
+                    return
+                
             if converted_paths == -1:
                 self.writeStatus("Conversion Failed")
             else:
@@ -455,6 +480,47 @@ class ConversionSettingsFrame(tk.Frame):
         globals.writeStatusQueue("Conversion Settings Not Saved (Cancelled)")
         self.master.destroy()
 
+class ToolpathPreviewFrame(tk.Frame):
+    def __init__(self, parent, toolpath):
+        super().__init__(parent)
+
+        self.cancelExport = False
+
+        self.titleLabel = tk.Label(self, text="Toolpath Preview")
+        self.titleLabel.pack(padx=10, pady=10, anchor="w")
+
+        self.buttonsFrame = tk.Frame(self)
+
+        self.continueButton = tk.Button(self.buttonsFrame, text="Continue Export", command=self.continueButtonCallback)
+        self.continueButton.pack(padx=5, pady=5, side="left")
+
+        self.cancelButton = tk.Button(self.buttonsFrame, text="Cancel Export", command=self.cancelButtonCallback)
+        self.cancelButton.pack(padx=5, pady=5, side="left")
+
+        self.buttonsFrame.pack(anchor="w")
+
+        self.textFrame = tk.Frame(self)
+
+        self.textArea = tk.Text(self.textFrame, wrap="none")
+        self.textArea.pack(side="left", anchor="w", fill="both", expand=True)
+        
+        self.textAreaScrollbar = tk.Scrollbar(self.textFrame, command=self.textArea.yview)
+        self.textAreaScrollbar.pack(side="right", fill="y")
+        self.textFrame.pack(padx=5, pady=5, fill="both", expand=True)
+
+        self.textArea['yscrollcommand'] = self.textAreaScrollbar.set
+
+        for line in toolpath:
+            self.textArea.insert(tk.END, line + "\n")
+
+        self.textArea.configure(state="disabled")
+
+    def continueButtonCallback(self):
+        self.master.destroy()
+
+    def cancelButtonCallback(self):
+        self.cancelExport = True
+        self.master.destroy()
 
 def queueLoop(rootObject):
     while True:

--- a/source/transpiler/guiRoot.py
+++ b/source/transpiler/guiRoot.py
@@ -484,7 +484,7 @@ class ToolpathPreviewFrame(tk.Frame):
     def __init__(self, parent, toolpath):
         super().__init__(parent)
 
-        self.cancelExport = False
+        self.cancelExport = True
 
         self.titleLabel = tk.Label(self, text="Toolpath Preview")
         self.titleLabel.pack(padx=10, pady=10, anchor="w")
@@ -516,10 +516,10 @@ class ToolpathPreviewFrame(tk.Frame):
         self.textArea.configure(state="disabled")
 
     def continueButtonCallback(self):
+        self.cancelExport = False
         self.master.destroy()
 
     def cancelButtonCallback(self):
-        self.cancelExport = True
         self.master.destroy()
 
 def queueLoop(rootObject):

--- a/source/transpiler/guiRoot.py
+++ b/source/transpiler/guiRoot.py
@@ -59,6 +59,9 @@ class GuiRoot(tk.Tk):
         self.menuTitleLabel = tk.Label(self, text=MENU_TITLE)
         self.menuTitleLabel.pack(anchor="center")
 
+        self.exitProgramButton = tk.Button(self, text="Exit Program", command=self.exitProgramButtonCallback)
+        self.exitProgramButton.pack(anchor="e", padx=10, pady=5, )
+
         # Import button + import filepath
         self.importFrame = tk.Frame(self)
 
@@ -154,6 +157,12 @@ class GuiRoot(tk.Tk):
         self.exportFilepathEntry.delete(0, tk.END)
         self.exportFilepathEntry.insert(tk.END, filepath)
         self.exportFilepathEntry.configure(state="readonly")
+
+    '''
+    Function that is called when the "Close Program" button is clicked
+    '''
+    def exitProgramButtonCallback(self):
+        self.destroy()
 
     '''
     Function that is called when the "Select Import File" button is clicked

--- a/source/transpiler/guiRoot.py
+++ b/source/transpiler/guiRoot.py
@@ -20,7 +20,7 @@ from toolpathExporter import ToolpathExporter  # Import ToolpathExporter
 import json
 
 WINDOW_TITLE = "S25-38"  # TODO - Provide suitable titles
-MENU_TITLE = "S25-38 Machine Instruction Converter"
+MENU_TITLE = "S25-38 Toolpath Converter"
 
 GUI_WINDOW_SIZE = "800x400"
 GUI_MIN_WIDTH = 400
@@ -111,7 +111,7 @@ class GuiRoot(tk.Tk):
 
         # Preview Toolpath Option
         self.previewCheckValue = tk.IntVar()
-        self.previewCheck = tk.Checkbutton(self, text="Preview Toolpath", variable=self.previewCheckValue)
+        self.previewCheck = tk.Checkbutton(self, text="Preview Toolpath Data", variable=self.previewCheckValue)
         self.previewCheck.pack()
 
         # Start Conversion Button

--- a/source/transpiler/guiRoot.py
+++ b/source/transpiler/guiRoot.py
@@ -224,8 +224,7 @@ class GuiRoot(tk.Tk):
                 EXPORT_FILE_TYPES_LIST.insert(0, ACSPL_FILE_TYPE)
 
         # Opens a dialog for user to set a filename and path for export
-        # filepath = filedialog.asksaveasfilename(filetypes = EXPORT_FILE_TYPES_LIST, defaultextension = EXPORT_FILE_TYPES_LIST[0])
-        filepath = filedialog.askdirectory()
+        filepath = filedialog.asksaveasfilename(filetypes = EXPORT_FILE_TYPES_LIST, defaultextension = EXPORT_FILE_TYPES_LIST[0])
         
         # User cancels setting export destination
         # If the user clicks the cancel button, an empty string is returned
@@ -426,7 +425,6 @@ def queueLoop(rootObject):
             break
     rootObject.after(QUEUE_LOOP_RATE, queueLoop, rootObject)
 
-#TODO - Fill out for conversion process, to be called when pressing start conversion button
 def conversionProcess(file_path, parameters, printer_type):
     parser = GenericParser(file_path)
     parsed_commands = parser.parse_commands()

--- a/source/transpiler/guiRoot.py
+++ b/source/transpiler/guiRoot.py
@@ -21,9 +21,16 @@ import json
 
 WINDOW_TITLE = "S25-38"  # TODO - Provide suitable titles
 MENU_TITLE = "S25-38 Machine Instruction Converter"
-GUI_WINDOW_SIZE = "800x400"
-TOOLPATH_PREVIEW_WINDOW_SIZE = "800x800"
 
+GUI_WINDOW_SIZE = "800x400"
+GUI_MIN_WIDTH = 400
+GUI_MIN_HEIGHT = 300
+
+TOOLPATH_PREVIEW_WINDOW_SIZE = "900x800"
+TOOLPATH_PREVIEW_WINDOW_MIN_WIDTH = 400
+TOOLPATH_PREVIEW_WINDOW_MIN_HEIGHT = 400
+
+# Controls how often the status queue is checked in milliseconds
 QUEUE_LOOP_RATE = 100
 
 # File Types
@@ -54,6 +61,7 @@ class GuiRoot(tk.Tk):
         # Title of the window
         self.title(WINDOW_TITLE)
         self.geometry(GUI_WINDOW_SIZE)
+        self.minsize(GUI_MIN_WIDTH, GUI_MIN_HEIGHT)
 
         # Title of Menu
         self.menuTitleLabel = tk.Label(self, text=MENU_TITLE)
@@ -405,9 +413,10 @@ class GuiRoot(tk.Tk):
                 toolpathPreviewWindow = tk.Toplevel()
                 toolpathPreviewWindow.grab_set()
                 self.eval("tk::PlaceWindow {} center".format(str(toolpathPreviewWindow)))
+                
                 toolpathPreviewWindow.geometry(TOOLPATH_PREVIEW_WINDOW_SIZE)
-
                 toolpathPreviewWindow.title("Toolpath Preview")
+                toolpathPreviewWindow.minsize(TOOLPATH_PREVIEW_WINDOW_MIN_WIDTH, TOOLPATH_PREVIEW_WINDOW_MIN_HEIGHT)
 
                 previewFrame = ToolpathPreviewFrame(toolpathPreviewWindow, converted_paths)
                 previewFrame.pack(padx=5, pady=5, fill="both", expand=True)

--- a/source/transpiler/guiRoot.py
+++ b/source/transpiler/guiRoot.py
@@ -324,7 +324,9 @@ class GuiRoot(tk.Tk):
             if(extensionIndex > 0):
                 self.export_path = self.export_path[0:extensionIndex] + newExtension
                 self.setExportFilepathDisplay(self.export_path)
-            
+        
+        else:
+            self.writeStatus("Conversion Settings Not Saved (Cancelled)")
 
     '''
     Function that is called when the "Printer Parameter" button is clicked
@@ -495,7 +497,6 @@ class ConversionSettingsFrame(tk.Frame):
 
     def cancelButtonCallback(self):
         # Close window without saving
-        globals.writeStatusQueue("Conversion Settings Not Saved (Cancelled)")
         self.master.destroy()
 
 class ToolpathPreviewFrame(tk.Frame):

--- a/source/transpiler/guiRoot.py
+++ b/source/transpiler/guiRoot.py
@@ -26,9 +26,12 @@ GUI_WINDOW_SIZE = "800x400"
 QUEUE_LOOP_RATE = 100
 
 # File Types
+NSCRYPT_EXTENSION = ".nff"
+ACSPL_EXTENSION = ".prg"
+
 CREO_FILE_TYPE = ("Creo Toolpath Files", '*.ncl.1')
-NSCRYPT_FILE_TYPE = ("nScrypt GCODE Files", '*.nff')
-ACSPL_FILE_TYPE = ("ACSPL Files", '*.prg')
+NSCRYPT_FILE_TYPE = ("nScrypt GCODE Files", '*' + NSCRYPT_EXTENSION)
+ACSPL_FILE_TYPE = ("ACSPL Files", '*' + ACSPL_EXTENSION)
 IMPORT_FILE_TYPES_LIST = [CREO_FILE_TYPE, ("All files", "*.*")]
 EXPORT_FILE_TYPES_LIST = [("All files", "*.*")]
 
@@ -134,6 +137,18 @@ class GuiRoot(tk.Tk):
         self.statusTextArea.delete("1.0", tk.END)
         self.statusTextArea.configure(state="disabled")
 
+    def setImportFilepathDisplay(self, filepath):
+        self.importFilepathEntry.configure(state="normal")
+        self.importFilepathEntry.delete(0, tk.END)
+        self.importFilepathEntry.insert(tk.END, filepath)
+        self.importFilepathEntry.configure(state="readonly")
+
+    def setExportFilepathDisplay(self, filepath):
+        self.exportFilepathEntry.configure(state="normal")
+        self.exportFilepathEntry.delete(0, tk.END)
+        self.exportFilepathEntry.insert(tk.END, filepath)
+        self.exportFilepathEntry.configure(state="readonly")
+
     '''
     Function that is called when the "Select Import File" button is clicked
     '''
@@ -166,11 +181,7 @@ class GuiRoot(tk.Tk):
 
                 self.import_path = filepath # Store import filepath
                 self.importFilename = filepath #used for params subsystem
-                
-                self.importFilepathEntry.configure(state="normal")
-                self.importFilepathEntry.delete(0, tk.END)
-                self.importFilepathEntry.insert(tk.END, filepath)
-                self.importFilepathEntry.configure(state="readonly")
+                self.setImportFilepathDisplay(filepath)
 
                 self.writeStatus("Select Import File Successful")
 
@@ -235,10 +246,7 @@ class GuiRoot(tk.Tk):
         else:
             self.export_path = filepath # Store export filepath
 
-            self.exportFilepathEntry.configure(state="normal")
-            self.exportFilepathEntry.delete(0, tk.END)
-            self.exportFilepathEntry.insert(tk.END, filepath)
-            self.exportFilepathEntry.configure(state="readonly")
+            self.setExportFilepathDisplay(filepath)
 
             self.writeStatus("Set Export Destination Successful")
 
@@ -265,15 +273,31 @@ class GuiRoot(tk.Tk):
 
         self.printParams.configure(state="normal") #enable the params menu, eve if it was only clicked but not saved
         if(convSettingsFrame.saveSuccess): # Check if the save button was actually pressed
+            convSettingsFrame.saveSuccess = False # Reset save flag
+
             #save/set which parameter type after window is closed
             #only do this if they intentionally press the button rather than close out after seeing warning
-            if globals.printerTypeSelected == 0:
-                self.params = NscryptParameters()
-            elif globals.printerTypeSelected == 1:
-                self.params = OptomecParameters()
-            
-            #TODO - if export_path != None, "change" extension of filepath
-            convSettingsFrame.saveSuccess = False # Reset save flag
+            # "change" extension of filepath if it already exists
+            extensionIndex = -1
+            newExtension = ""
+            if (self.export_path != None):
+                extensionIndex = self.export_path.rfind(".")
+
+            match globals.printerTypeSelected:
+                case globals.PrinterType.NSCRYPT:
+                    self.params = NscryptParameters()
+                    newExtension = NSCRYPT_EXTENSION
+
+                case globals.PrinterType.OPTOMEC:
+                    self.params = OptomecParameters()
+                    newExtension = ACSPL_EXTENSION
+
+                case _:
+                    raise ValueError("Invalid Printer Type Selected")
+                
+            if(extensionIndex > 0):
+                self.export_path = self.export_path[0:extensionIndex] + newExtension
+                self.setExportFilepathDisplay(self.export_path)
 
     '''
     Function that is called when the "Printer Parameter" button is clicked

--- a/source/transpiler/guiRoot.py
+++ b/source/transpiler/guiRoot.py
@@ -414,9 +414,9 @@ class GuiRoot(tk.Tk):
                 toolpathPreviewWindow.grab_set()
                 self.eval("tk::PlaceWindow {} center".format(str(toolpathPreviewWindow)))
                 
-                toolpathPreviewWindow.geometry(TOOLPATH_PREVIEW_WINDOW_SIZE)
                 toolpathPreviewWindow.title("Toolpath Preview")
                 toolpathPreviewWindow.minsize(TOOLPATH_PREVIEW_WINDOW_MIN_WIDTH, TOOLPATH_PREVIEW_WINDOW_MIN_HEIGHT)
+                toolpathPreviewWindow.geometry(TOOLPATH_PREVIEW_WINDOW_SIZE)
 
                 previewFrame = ToolpathPreviewFrame(toolpathPreviewWindow, converted_paths)
                 previewFrame.pack(padx=5, pady=5, fill="both", expand=True)

--- a/source/transpiler/toolpathExporter.py
+++ b/source/transpiler/toolpathExporter.py
@@ -49,19 +49,13 @@ class ToolpathExporter:
         """
         if not self.validate_toolpath(toolpath):
             return "Error: Invalid toolpath."
-        
-        if not os.path.isdir(self.export_path):
-            return "Error: Export path does not exist."
-
-        file_extension = self.supported_formats.get(self.printer_type, ".txt")
-        file_name = os.path.join(self.export_path, f"exported_toolpath{file_extension}")
 
         try:
-            with open(file_name, "w", encoding="utf-8") as file:
+            with open(self.export_path, "w", encoding="utf-8") as file:
                 for line in toolpath:
                     file.write(line + "\n")
-            writeStatusQueue(f"Export successful: {file_name}")
-            return f"Export successful: {file_name}"
+            writeStatusQueue(f"Export successful: {self.export_path}")
+            return f"Export successful: {self.export_path}"
         except Exception as e:
             writeStatusQueue(f"Error: {str(e)}")
             return f"Error: {str(e)}"

--- a/source/transpiler/toolpathExporter.py
+++ b/source/transpiler/toolpathExporter.py
@@ -54,8 +54,6 @@ class ToolpathExporter:
             with open(self.export_path, "w", encoding="utf-8") as file:
                 for line in toolpath:
                     file.write(line + "\n")
-            writeStatusQueue(f"Export successful: {self.export_path}")
             return f"Export successful: {self.export_path}"
         except Exception as e:
-            writeStatusQueue(f"Error: {str(e)}")
             return f"Error: {str(e)}"

--- a/tests/gui_manual_testing.md
+++ b/tests/gui_manual_testing.md
@@ -24,7 +24,7 @@ Follow the following procedure to manually test GUI functionality. The steps are
 13. Check that a status message appears: "Conversion Settings Not Saved (Cancelled)"
 14. Check the following:
     - Select Import File Button is INTERACTABLE
-    - Conversion Settings Button is NOT INTERACTABLE
+    - Conversion Settings Button is INTERACTABLE
     - Printer Parameters Button is NOT INTERACTABLE
     - Set Export Destination Button is NOT INTERACTABLE
     - Start Conversion Button is NOT INTERACTABLE
@@ -34,9 +34,9 @@ Follow the following procedure to manually test GUI functionality. The steps are
 18. Check that a status message appears: "Conversion Settings Saved" with the corresponding settings that were set. 
 19. Close the Conversion Settings Window.
 20. Check the following:
+    - Select Import File Button is INTERACTABLE
     - Conversion Settings Button is INTERACTABLE
     - Printer Parameters Button is INTERACTABLE
-    - Select Import File Button is INTERACTABLE
     - Set Export Destination Button is INTERACTABLE
     - Start Conversion Button is NOT INTERACTABLE
 21. Click on the Printer Parameters Button. (Possibly more thorough testing steps needed.)

--- a/tests/gui_manual_testing.md
+++ b/tests/gui_manual_testing.md
@@ -20,51 +20,52 @@ Follow the following procedure to manually test GUI functionality. The steps are
 9. Check that the Import Filepath is accurately reflected on the main menu.
 10. Click on the Conversion Settings Button.
 11. Select Printer Type.
-12. Close the Conversion Settings Window WITHOUT SAVING.
-13. Check the following:
+12. Click on the Cancel Button.
+13. Check that a status message appears: "Conversion Settings Not Saved (Cancelled)"
+14. Check the following:
     - Select Import File Button is INTERACTABLE
     - Conversion Settings Button is NOT INTERACTABLE
     - Printer Parameters Button is NOT INTERACTABLE
     - Set Export Destination Button is NOT INTERACTABLE
     - Start Conversion Button is NOT INTERACTABLE
-14. Click on the Conversion Settings Button.
-15. Select Printer Type.
-16. Click Save.
-17. Check that a status message appears: "Conversion Settings Saved" with the corresponding settings that were set. 
-18. Close the Conversion Settings Window.
-19. Check the following:
+15. Click on the Conversion Settings Button.
+16. Select Printer Type.
+17. Click Save & Exit.
+18. Check that a status message appears: "Conversion Settings Saved" with the corresponding settings that were set. 
+19. Close the Conversion Settings Window.
+20. Check the following:
     - Conversion Settings Button is INTERACTABLE
     - Printer Parameters Button is INTERACTABLE
     - Select Import File Button is INTERACTABLE
     - Set Export Destination Button is INTERACTABLE
     - Start Conversion Button is NOT INTERACTABLE
-20. Click on the Printer Parameters Button. (Possibly more thorough testing steps needed.)
-21. Select and Save Applicable Printer Parameters.
-22. Close Printer Parameters Window.
-23. Check the following:
+21. Click on the Printer Parameters Button. (Possibly more thorough testing steps needed.)
+22. Select and Save Applicable Printer Parameters.
+23. Close Printer Parameters Window.
+24. Check the following:
     - Conversion Settings Button is INTERACTABLE
     - Printer Parameters Button is INTERACTABLE
     - Select Import File Button is INTERACTABLE
     - Set Export Destination Button is INTERACTABLE
     - Start Conversion Button is NOT INTERACTABLE
-24. Click Set Export Destination Button.
-25. Cancel Folder Selection.
-26. Check that a status message appears: "Set Export Destination: Cancelled"
-27. Check the following:
+25. Click Set Export Destination Button.
+26. Cancel Folder Selection.
+27. Check that a status message appears: "Set Export Destination: Cancelled"
+28. Check the following:
     - Conversion Settings Button is INTERACTABLE
     - Printer Parameters Button is INTERACTABLE
     - Select Import File Button is INTERACTABLE
     - Set Export Destination Button is INTERACTABLE
     - Start Conversion Button is NOT INTERACTABLE
-28. Click Set Export Destination Button.
-29. Select Destination Folder.
-30. Check that a status message appears: "Set Export Destination: Successful"
-31. Check the following:
+29. Click Set Export Destination Button.
+30. Select Destination Folder.
+31. Check that a status message appears: "Set Export Destination: Successful"
+32. Check the following:
     - Conversion Settings Button is INTERACTABLE
     - Printer Parameters Button is INTERACTABLE
     - Select Import File Button is INTERACTABLE
     - Set Export Destination Button is INTERACTABLE
     - Start Conversion Button is INTERACTABLE
-32. Check that the Export Filepath is accurately reflected on the main menu.
-33. Click Start Conversion Button.
-34. Check that the Conversion Process is executed with appropriate status messages.
+33. Check that the Export Filepath is accurately reflected on the main menu.
+34. Click Start Conversion Button.
+35. Check that the Conversion Process is executed with appropriate status messages.

--- a/tests/test_guiRoot.py
+++ b/tests/test_guiRoot.py
@@ -15,10 +15,41 @@ import guiRoot
 import tkinter as tk
 import applicationGlobals as globals
 
+'''
+Helper function to easily test different strings
+for testing internally, when writing directly to status within the GUI, set internal to true
+for testing with the status queue, set internal to false
+'''
+def testStatusWithString(testString, guiRootObject, internal):
+    guiRootObject.clearStatus()
+
+    match (internal):
+        case True:
+            guiRootObject.writeStatus(testString)
+            
+        case False:
+            globals.writeStatusQueue(testString)
+            guiRoot.queueLoop(guiRootObject) # Have to "artificially" loop through queue
+        case _:
+            raise ValueError("Invalid Value for \"internal\"")
+    
+    testStartIndex = len(testString) * -1
+
+    receivedString = guiRootObject.statusTextArea.get("1.0", tk.END).strip()    # Get string from status area, remove whitespace(including newline characters)
+    receivedString = receivedString[testStartIndex:]                            # Extract only the target string
+
+    assert  testString == receivedString # Check
+
 class TestGuiRoot(unittest.TestCase):
     def setUp(self):
         self.guiRootObj = guiRoot.GuiRoot()
-
+        self.testStringList = ["TEST1", "TEST2", "Alphabetical Characters", "Numbers 0123456789", "Special Characters `~!@#$%^&*()_+"]
+        guiRoot.queueLoop(self.guiRootObj)
+        self.guiRootObj.clearStatus()
+    
+    '''
+    Test Select Import File Button
+    '''
     def test_Import(self):
         importMock = mock.Mock()
 
@@ -28,6 +59,9 @@ class TestGuiRoot(unittest.TestCase):
         
         importMock.assert_called()
     
+    '''
+    Test Set Export Destination Button
+    '''
     def test_Export(self):
         exportMock = mock.Mock()
 
@@ -37,6 +71,9 @@ class TestGuiRoot(unittest.TestCase):
         
         exportMock.assert_called()
 
+    '''
+    Test Conversion Settings Button
+    '''
     def test_ConvSettings(self):
         convSettingsMock = mock.Mock()
 
@@ -45,7 +82,10 @@ class TestGuiRoot(unittest.TestCase):
         self.guiRootObj.conversionSettings.invoke()
         
         convSettingsMock.assert_called()
-
+    
+    '''
+    Test Start Conversion Button
+    '''
     def test_StartConv(self):
         startConvMock = mock.Mock()
 
@@ -54,45 +94,20 @@ class TestGuiRoot(unittest.TestCase):
         self.guiRootObj.startConvButton.invoke()
         
         startConvMock.assert_called()
-    
+
+    '''
+    Test the internal writeStatus() function
+    '''
     def test_WriteStatus(self):
-        self.guiRootObj.clearStatus()
-        self.guiRootObj.writeStatus("Alphabetical Characters")
-        assert self.guiRootObj.statusTextArea.get("1.0", tk.END)[11:] == "Alphabetical Characters\n\n"
+        for string in self.testStringList:
+            testStatusWithString(string, self.guiRootObj, internal=True)
 
-        self.guiRootObj.clearStatus()
-        self.guiRootObj.writeStatus("Numbers 0123456789")
-        assert self.guiRootObj.statusTextArea.get("1.0", tk.END)[11:] == "Numbers 0123456789\n\n"
-
-        self.guiRootObj.clearStatus()
-        self.guiRootObj.writeStatus("Special Characters `~!@#$%^&*()_+")
-        assert self.guiRootObj.statusTextArea.get("1.0", tk.END)[11:] == "Special Characters `~!@#$%^&*()_+\n\n"
-
+    '''
+    Test writing to the status area via the status queue
+    '''
     def test_StatusQueue(self):
-        self.guiRootObj.clearStatus()
-        globals.writeStatusQueue("TEST1")
-        guiRoot.queueLoop(self.guiRootObj) # Have to "artificially" loop through queue 
-        assert self.guiRootObj.statusTextArea.get("1.0", tk.END)[11:] == "TEST1\n\n"
-
-        self.guiRootObj.clearStatus()
-        globals.writeStatusQueue("TEST2")
-        guiRoot.queueLoop(self.guiRootObj)
-        assert self.guiRootObj.statusTextArea.get("1.0", tk.END)[11:] == "TEST2\n\n"
-
-        self.guiRootObj.clearStatus()
-        globals.writeStatusQueue("Alphabetical Characters")
-        guiRoot.queueLoop(self.guiRootObj)
-        assert self.guiRootObj.statusTextArea.get("1.0", tk.END)[11:] == "Alphabetical Characters\n\n"
-
-        self.guiRootObj.clearStatus()
-        globals.writeStatusQueue("Numbers 0123456789")
-        guiRoot.queueLoop(self.guiRootObj)
-        assert self.guiRootObj.statusTextArea.get("1.0", tk.END)[11:] == "Numbers 0123456789\n\n"
-
-        self.guiRootObj.clearStatus()
-        globals.writeStatusQueue("Special Characters `~!@#$%^&*()_+")
-        guiRoot.queueLoop(self.guiRootObj)
-        assert self.guiRootObj.statusTextArea.get("1.0", tk.END)[11:] == "Special Characters `~!@#$%^&*()_+\n\n"
+        for string in self.testStringList:
+            testStatusWithString(string, self.guiRootObj, internal=False)
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_int_toolPathExporter.py
+++ b/tests/test_int_toolPathExporter.py
@@ -12,17 +12,16 @@ from acsplConverter import AcsplConverter
 
 class TestIntegrationToolpathExporter(unittest.TestCase):
     def setUp(self):
-        self.export_path = "test_exports"
-        self.gui = GuiRoot()
+        self.tempDir = "tempDir"
         self.nscrypt_converter = NscryptConverter()
         self.acspl_converter = AcsplConverter()
-        os.makedirs(self.export_path, exist_ok=True)
+        os.makedirs(self.tempDir, exist_ok=True)
 
     def tearDown(self):
-        if os.path.exists(self.export_path):
-            for file in os.listdir(self.export_path):
-                os.remove(os.path.join(self.export_path, file))
-            os.rmdir(self.export_path)
+        if os.path.exists(self.tempDir):
+            for file in os.listdir(self.tempDir):
+                os.remove(os.path.join(self.tempDir, file))
+            os.rmdir(self.tempDir)
 
     # def test_export_includes_machine_parameters(self):
     #     """Test if ToolpathExporter integrates machine parameters correctly."""
@@ -55,14 +54,15 @@ class TestIntegrationToolpathExporter(unittest.TestCase):
         toolpath_data = [{"move": {"x": 10, "y": 10, "z": 5}}]
         converted_data = self.nscrypt_converter.translate(toolpath_data)
         
-        exporter = ToolpathExporter(self.export_path, "nScrypt")
+        filepath = self.tempDir + "/exported_toolpath.nff"
+        exporter = ToolpathExporter(filepath, "nScrypt")
         result = exporter.export(converted_data)
         self.assertIn("Export successful", result)
 
-        output_files = os.listdir(self.export_path)
+        output_files = os.listdir(self.tempDir)
         self.assertGreater(len(output_files), 0)
         
-        with open(os.path.join(self.export_path, output_files[0]), "r") as f:
+        with open(os.path.join(self.tempDir, output_files[0]), "r") as f:
             content = f.read()
             self.assertIn("10.0 10.0 5.0 0.0 0.0", content)
 
@@ -87,14 +87,15 @@ class TestIntegrationToolpathExporter(unittest.TestCase):
         toolpath_data = [{"move": {"x": 20, "y": 30, "z": 10}}]
         converted_data = self.nscrypt_converter.translate(toolpath_data)
         
-        exporter = ToolpathExporter(self.export_path, "nScrypt")
+        filepath = self.tempDir + "/exported_toolpath.nff"
+        exporter = ToolpathExporter(filepath, "nScrypt")
         result = exporter.export(converted_data)
         self.assertIn("Export successful", result)
 
-        output_files = os.listdir(self.export_path)
+        output_files = os.listdir(self.tempDir)
         self.assertGreater(len(output_files), 0)
         
-        with open(os.path.join(self.export_path, output_files[0]), "r") as f:
+        with open(os.path.join(self.tempDir, output_files[0]), "r") as f:
             content = f.read()
             self.assertIn("20.0 30.0 10.0 0.0 0.0", content)
 

--- a/tests/test_toolpathExporter.py
+++ b/tests/test_toolpathExporter.py
@@ -1,7 +1,5 @@
 import unittest
 import os
-import tempfile
-
 import sys
 
 # Get absolute path to the source/transpiler directory
@@ -11,42 +9,44 @@ from toolpathExporter import ToolpathExporter
 
 class TestToolpathExporter(unittest.TestCase):
     def setUp(self):
-        self.export_path = "test_exports"
-        self.exporter = ToolpathExporter(self.export_path, "nScrypt")
-        os.makedirs(self.export_path, exist_ok=True)
+        self.tempDir = "tempDir"
+        os.makedirs(self.tempDir, exist_ok=True)
 
     def tearDown(self):
         # Cleanup exported files after each test
-        for file in os.listdir(self.export_path):
-            os.remove(os.path.join(self.export_path, file))
-        os.rmdir(self.export_path)
+        for file in os.listdir(self.tempDir):
+            os.remove(os.path.join(self.tempDir, file))
+        os.rmdir(self.tempDir)
 
     def test_export_success(self):
         """Test exporting a valid toolpath for nScrypt"""
+        filepath = self.tempDir + "/exported_toolpath.nff"
+        exporter = ToolpathExporter(filepath, "nScrypt")
         toolpath_data = ["MOVE X10 Y10 Z5 F300", "SET SPEED 100", ""]  # Includes empty line
-        result = self.exporter.export(toolpath_data)
+        result = exporter.export(toolpath_data)
         self.assertIn("Export successful", result)
 
-        file_path = os.path.join(self.export_path, "exported_toolpath.nff")
-        with open(file_path, "r", encoding="utf-8") as file:
+        with open(filepath, "r", encoding="utf-8") as file:
             content = file.read().splitlines()
         self.assertEqual(content, toolpath_data)  # Ensure file contents match exactly
 
     def test_export_acspl_success(self):
         """Test exporting a valid ACSPL toolpath for Optomec"""
-        exporter = ToolpathExporter(self.export_path, "Optomec")
+        filepath = self.tempDir + "/exported_toolpath.prg"
+        exporter = ToolpathExporter(filepath, "Optomec")
         toolpath_data = ["!Machine Type - Optomec 5-axis Aerosol Jet", "XSEG/A (10,11,12,14,15)", ""]
         result = exporter.export(toolpath_data)
         self.assertIn("Export successful", result)
 
-        file_path = os.path.join(self.export_path, "exported_toolpath.prg")
-        with open(file_path, "r", encoding="utf-8") as file:
+        with open(filepath, "r", encoding="utf-8") as file:
             content = file.read().splitlines()
         self.assertEqual(content, toolpath_data)
 
     def test_export_empty_toolpath(self):
         """Test exporting an empty toolpath, which should fail"""
-        result = self.exporter.export([])
+        filepath = self.tempDir + "/test_empty.nff"
+        exporter = ToolpathExporter(filepath, "nScrypt")
+        result = exporter.export([])
         self.assertIn("Error", result)
 
     def test_export_no_export_path(self):


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/92e52903-8ff7-49b9-acc5-8d45fd8c6dde)

- User can now specify filename when setting export destination
     - Export subsystem and related tests adjusted accordingly
- Modified GUI test script to run properly alongside other tests
- Conversion Settings Window Changes
     - Added dedicated cancel button
     - Modifed save button to "Overwrite Save & Exit" / "Save & Exit"
     - Minor layout changes

![image](https://github.com/user-attachments/assets/34e3fd25-495a-4c60-95f8-b6869b88a56c)
![image](https://github.com/user-attachments/assets/c2b96856-6ec0-4ccb-b862-83936cbee235)

- Added toolpath preview window. If selected, appears after starting conversion process and before export

![image](https://github.com/user-attachments/assets/de3c427b-dc4c-4854-95f9-79022c33c9f4)
![image](https://github.com/user-attachments/assets/5b0d22fb-13bb-4590-81bd-e43ff14aee2a)

- "Usage Enforcement" Updates
     - If an export destination is already set, changing printer type will automatically change the export file's filetype/extension
     - If a parameter file is not found when importing (default/first launch behavior), user will need to set conversion settings before being allowed to set an export destination. Otherwise, if a parameter file is found, user may directly set the export destination after importing.
- Added dedicated button to exit the program

Likely some other changes to be made. However, this seems like a fair amount of changes for now. 