### PR TITLE
Added unit conversion

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pytest
 numpy
+pyinstaller

--- a/source/transpiler/acsplConverter.py
+++ b/source/transpiler/acsplConverter.py
@@ -204,21 +204,21 @@ class Machine:
         :param b: desired location for b-axis
         :return: none
         """
-        # If the units are inches, convert to mm with
+        # If the units are inches, convert to mm with nanometer accuracy
         if self._units == "inches":
-            self._X = x * 25.4
-            self._Y = y * 25.4
-            self._Z = z * 25.4
-            self._A = a * 25.4
-            self._B = b * 25.4
+            self._X = round(float(x) * 25.4, 9)
+            self._Y = round(float(y) * 25.4, 9)
+            self._Z = round(float(z) * 25.4, 9)
+            self._A = round(float(a) * 25.4, 9)
+            self._B = round(float(b) * 25.4, 9)
 
-        # If the units are mm, set the axis registers to the desired location
+        # If the units are mm, set the axis registers to the desired location with nanometer accuracy
         elif self._units == "mm":
-            self._X = x
-            self._Y = y
-            self._Z = z
-            self._A = a
-            self._B = b
+            self._X = round(float(x), 9)
+            self._Y = round(float(y), 9)
+            self._Z = round(float(z), 9)
+            self._A = round(float(a), 9)
+            self._B = round(float(b), 9)
 
 
     def get_axis_registers(self) -> tuple[float, float, float, float, float]:

--- a/source/transpiler/acsplConverter.py
+++ b/source/transpiler/acsplConverter.py
@@ -510,13 +510,13 @@ class AcsplConverter(ToolpathConverter):
         # Notify user of start of transpiling
         notify_and_log("Transpiling to ACSPL...")
 
-        # Set the units for the machine
-        self._set_units(parsed_commands)
-
         # Check if the provided parsed commands is valid
         if not self._validate_translate_arg(parsed_commands):
             notify_and_log("Invalid argument provided to ACSPL translate function")
             return []
+
+        # Set the units for the machine
+        self._set_units(parsed_commands)
 
         # Append the machine setup code block
         self._translated_commands.append(self._get_header())

--- a/source/transpiler/acsplConverter.py
+++ b/source/transpiler/acsplConverter.py
@@ -204,11 +204,22 @@ class Machine:
         :param b: desired location for b-axis
         :return: none
         """
-        self._X = float(x)
-        self._Y = float(y)
-        self._Z = float(z)
-        self._A = float(a)
-        self._B = float(b)
+        # If the units are inches, convert to mm with
+        if self._units == "inches":
+            self._X = x * 25.4
+            self._Y = y * 25.4
+            self._Z = z * 25.4
+            self._A = a * 25.4
+            self._B = b * 25.4
+
+        # If the units are mm, set the axis registers to the desired location
+        elif self._units == "mm":
+            self._X = x
+            self._Y = y
+            self._Z = z
+            self._A = a
+            self._B = b
+
 
     def get_axis_registers(self) -> tuple[float, float, float, float, float]:
         """

--- a/source/transpiler/acsplConverter.py
+++ b/source/transpiler/acsplConverter.py
@@ -101,7 +101,7 @@ class Machine:
         self._done: bool = False
 
         # Units
-        self.units = "mm"
+        self._units = "mm"
 
         # Axis Registers
         self._X: any = None
@@ -183,7 +183,7 @@ class Machine:
         Getter for units
         :return: units
         """
-        return self.units
+        return self._units
 
     @units.setter
     def units(self, units: str):
@@ -192,7 +192,7 @@ class Machine:
         :param units: units to be set
         :return: none
         """
-        self.units = units
+        self._units = units
 
     def set_axis_registers(self, x: any, y: any, z: any, a: any, b: any) -> None:
         """
@@ -335,6 +335,36 @@ class AcsplConverter(ToolpathConverter):
         # If all checks pass
         return True
 
+    def _set_units(self, commands) -> None:
+        """
+        Set the units for the machine
+        :param commands: list of commands to be processed
+        :return: None
+        """
+
+        # Iterate through the commands
+        for command in commands:
+            # If the command is a units command
+            if "units" in command:
+                # If the units are inches
+                if command["units"]["units"] == "INCHES":
+                    # Set the units for the machine
+                    self.machine.units = "inches"
+                    # Notify user of the units
+                    notify_and_log(f"Units found in input file = '{command["units"]["units"]}', will convert to mm.")
+                    return
+                # If the units are mm
+                elif command["units"]["units"] == "MILLIMETERS":
+                    # Set the units for the machine
+                    self.machine.units = "mm"
+                    # Notify user of the units
+                    notify_and_log(f"Units found in input file = '{command["units"]["units"]}', will convert to mm.")
+                    return
+
+        # If no units command is found, set the default units to mm
+        self.machine.units = "mm"
+        notify_and_log("Units not provided, defaulting to mm")
+
     def _process_command(self, command: str, params: dict[str, str]) -> None:
         """
         Processes a single command
@@ -468,6 +498,9 @@ class AcsplConverter(ToolpathConverter):
 
         # Notify user of start of transpiling
         notify_and_log("Transpiling to ACSPL...")
+
+        # Set the units for the machine
+        self._set_units(parsed_commands)
 
         # Check if the provided parsed commands is valid
         if not self._validate_translate_arg(parsed_commands):

--- a/source/transpiler/acsplConverter.py
+++ b/source/transpiler/acsplConverter.py
@@ -101,7 +101,7 @@ class Machine:
         self._done: bool = False
 
         # Units
-        self.units = None
+        self.units = "mm"
 
         # Axis Registers
         self._X: any = None

--- a/source/transpiler/acsplConverter.py
+++ b/source/transpiler/acsplConverter.py
@@ -100,6 +100,9 @@ class Machine:
         # Flag if done with processing toolpath
         self._done: bool = False
 
+        # Units
+        self.units = None
+
         # Axis Registers
         self._X: any = None
         self._Y: any = None
@@ -173,6 +176,23 @@ class Machine:
         :return: none
         """
         self._done = done
+
+    @property
+    def units(self):
+        """
+        Getter for units
+        :return: units
+        """
+        return self.units
+
+    @units.setter
+    def units(self, units: str):
+        """
+        Setter for units
+        :param units: units to be set
+        :return: none
+        """
+        self.units = units
 
     def set_axis_registers(self, x: any, y: any, z: any, a: any, b: any) -> None:
         """

--- a/tests/test_acsplConverter.py
+++ b/tests/test_acsplConverter.py
@@ -224,6 +224,33 @@ class TestAcsplConverter(unittest.TestCase):
         # Assert
         self.assertTrue(all(res == [] for res in [res_int, res_float, res_str, res_none, res_dict]))
 
+    def test_units_inches_parsing(self):
+        # Arrange
+        INCHES_COMMAND = [
+            {"units": {"units": "INCHES"}},
+            {"move": {"x": "1.0", "y": "2.0", "z": "3.0"}}
+        ]
+
+        # Act
+        result = self.acsplConverter.translate(INCHES_COMMAND)
+
+        # Assert
+        self.assertEqual(self.acsplConverter.machine.units, "inches")
+        self.assertIn("PTP/EV (10,11,12,14,15), 25.4, 50.8, 76.2, 0.0, 0.0, gDblRapidSpeed",result)
+
+    def test_units_default_parsing(self):
+        # Arrange
+        INCHES_COMMAND = [
+            {"move": {"x": "1.0", "y": "2.0", "z": "3.0"}}
+        ]
+
+        # Act
+        result = self.acsplConverter.translate(INCHES_COMMAND)
+
+        # Assert
+        self.assertEqual(self.acsplConverter.machine.units, "mm")
+        self.assertIn("PTP/EV (10,11,12,14,15), 1.0, 2.0, 3.0, 0.0, 0.0, gDblRapidSpeed",result)
+
     def test_print_parsed_commands(self):
         results = self.acsplConverter.translate(PARSED_COMMANDS)
         #_print(results)


### PR DESCRIPTION
This pull request introduces functionality to handle unit conversions in the `acsplConverter` class, ensuring compatibility with both millimeters and inches. The changes include adding a new `_units` attribute, implementing unit conversion logic, and integrating unit detection from input commands.

### Unit Handling Enhancements:

* Added a `_units` attribute to the `acsplConverter` class, defaulting to `"mm"`, along with a getter and setter for managing units (`source/transpiler/acsplConverter.py`, [[1]](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eR103-R105) [[2]](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eR180-R196).

* Updated the `set_axis_registers` method to convert axis register values to millimeters if the units are specified as inches, ensuring nanometer accuracy (`source/transpiler/acsplConverter.py`, [source/transpiler/acsplConverter.pyL187-R222](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eL187-R222)).

* Introduced a `_set_units` method to parse and set the units based on input commands, defaulting to millimeters if no units are specified. This method logs the detected or defaulted unit type for transparency (`source/transpiler/acsplConverter.py`, [source/transpiler/acsplConverter.pyR349-R378](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eR349-R378)).

* Integrated the `_set_units` method into the `translate` function to ensure units are determined before processing commands (`source/transpiler/acsplConverter.py`, [source/transpiler/acsplConverter.pyR518-R520](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eR518-R520)).
This pull request introduces unit handling to the `acsplConverter` class, enabling support for both millimeter and inch units. Key updates include adding a unit property to the machine, implementing unit conversion logic, and enhancing the test suite to validate these changes.

### Unit Handling Enhancements:

* Added a `_units` property to the `acsplConverter` class, with getter and setter methods for managing units (`mm` or `inches`). (`source/transpiler/acsplConverter.py`, [[1]](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eR103-R105) [[2]](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eR180-R196)
* Updated the `set_axis_registers` method to convert coordinates to millimeters if the units are set to `inches`. Ensures nanometer-level precision during conversions. (`source/transpiler/acsplConverter.py`, [source/transpiler/acsplConverter.pyL187-R222](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eL187-R222))

### Unit Detection and Defaulting:

* Implemented a `_set_units` method to detect and set units based on parsed commands. Defaults to `mm` if no unit information is provided. (`source/transpiler/acsplConverter.py`, [source/transpiler/acsplConverter.pyR349-R378](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eR349-R378))
* Integrated `_set_units` into the `translate` method to initialize unit settings before processing commands. (`source/transpiler/acsplConverter.py`, [source/transpiler/acsplConverter.pyR518-R520](diffhunk://#diff-68ef139abc15fcef825618cbd828a575737db98a8b3b455690136d37b2a9e17eR518-R520))

### Test Suite Updates:

* Added `test_units_inches_parsing` to verify proper handling of commands with `inches` units and their conversion to millimeters. (`tests/test_acsplConverter.py`, [tests/test_acsplConverter.pyR227-R253](diffhunk://#diff-036821cd163113b1d061ad9ad26a80a7ac0655086e3c4346269d0bf89d058e77R227-R253))
* Added `test_units_default_parsing` to confirm that the default unit is `mm` when no unit information is provided. (`tests/test_acsplConverter.py`, [tests/test_acsplConverter.pyR227-R253](diffhunk://#diff-036821cd163113b1d061ad9ad26a80a7ac0655086e3c4346269d0bf89d058e77R227-R253))